### PR TITLE
Fix sanitizeHtml regex for unquoted attributes

### DIFF
--- a/apps/firebase/functions/src/utils/xssSanitization.ts
+++ b/apps/firebase/functions/src/utils/xssSanitization.ts
@@ -144,7 +144,10 @@ export function sanitizeHtml(
     // Clean attributes
     let cleanedAttributes = attributes;
     DANGEROUS_ATTRIBUTES.forEach((attr) => {
-      const attrRegex = new RegExp(`\\s*${attr}\\s*=\\s*["'][^"']*["']`, "gi");
+      const attrRegex = new RegExp(
+        `\\s*${attr}\\s*=\\s*(?:"[^"]*"|'[^']*'|[^\\s>]+)`,
+        "gi"
+      );
       cleanedAttributes = cleanedAttributes.replace(attrRegex, "");
     });
 


### PR DESCRIPTION
## Summary
- improve sanitizeHtml to remove dangerous attributes even when values are unquoted

## Testing
- `npm test --silent` *(fails: Property 'sessionId' does not exist etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68429493c394832a87671ba47b035534