### PR TITLE
Fix navigation mock in login test

### DIFF
--- a/apps/web/dynastyweb/jest.setup.enhanced.js
+++ b/apps/web/dynastyweb/jest.setup.enhanced.js
@@ -11,6 +11,7 @@
 
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+import React from 'react'
 
 // =============================================================================
 // ENVIRONMENT SETUP

--- a/apps/web/dynastyweb/src/__tests__/auth/login.test.tsx
+++ b/apps/web/dynastyweb/src/__tests__/auth/login.test.tsx
@@ -1,5 +1,7 @@
 // Mock dependencies BEFORE imports
-jest.mock('next/navigation');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
 jest.mock('@/lib/firebase', () => ({
   auth: {},
   db: {},


### PR DESCRIPTION
## Summary
- mock `next/navigation` in login tests
- import React in jest setup to avoid undefined error

## Testing
- `yarn lint:all` *(fails: react/no-unescaped-entities)*
- `yarn test:all` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_b_6849a80cdcc0832aa764b8c0412705d8