### PR TITLE
fix: escape apostrophe in EditMemberDialog

### DIFF
--- a/apps/web/dynastyweb/src/components/EditMemberDialog.tsx
+++ b/apps/web/dynastyweb/src/components/EditMemberDialog.tsx
@@ -145,7 +145,7 @@ export function EditMemberDialog({
             Update information for {member.displayName}
             {member.isPendingSignUp && (
               <span className="block mt-2 text-sm text-amber-600">
-                This member hasn't joined Dynasty yet. You can update their information.
+                This member hasn&rsquo;t joined Dynasty yet. You can update their information.
               </span>
             )}
           </DialogDescription>


### PR DESCRIPTION
## Summary
- escape the apostrophe in EditMemberDialog to fix lint error

## Testing
- `yarn lint:all` *(fails: Couldn't find the node_modules state file)*
- `yarn test:all` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_b_6849a825e258832a9693ded9f7e6fe09