### PR TITLE
chore: enforce type and lint checks

### DIFF
--- a/apps/web/dynastyweb/next.config.js
+++ b/apps/web/dynastyweb/next.config.js
@@ -2,13 +2,8 @@
 const nextConfig = {
   typescript: {
     tsconfigPath: './tsconfig.json',
-    // Ignore TypeScript errors during build (for deployment)
-    ignoreBuildErrors: true,
   },
-  eslint: {
-    // Ignore ESLint errors during build (for deployment)
-    ignoreDuringBuilds: true,
-  },
+  eslint: {},
   transpilePackages: ['ui', 'utils'],
   
   // Environment variables


### PR DESCRIPTION
## Summary
- ensure Next.js build fails on TypeScript or ESLint errors

## Testing
- `yarn lint:all` *(fails: package not in lockfile)*
- `yarn test:all` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6849a7eba654832ab3b8bcd6dd26bb12