### PR TITLE
Add userId support to email utilities

### DIFF
--- a/apps/firebase/functions/src/__tests__/auth-functions.test.ts
+++ b/apps/firebase/functions/src/__tests__/auth-functions.test.ts
@@ -734,6 +734,7 @@ describe("Password Management Functions", () => {
       mockAuth.generatePasswordResetLink.mockResolvedValue("https://reset-link");
       mockAuth.getUserByEmail.mockResolvedValue({
         displayName: "Test User",
+        uid: "uid123",
       });
 
       const emailModule = jest.requireMock("../auth/config/emailConfig");
@@ -750,6 +751,7 @@ describe("Password Management Functions", () => {
           username: "Test User",
           resetLink: "https://reset-link",
         },
+        userId: "uid123",
       });
     });
   });

--- a/apps/firebase/functions/src/auth/config/emailConfig.ts
+++ b/apps/firebase/functions/src/auth/config/emailConfig.ts
@@ -41,9 +41,17 @@ export function getEmailProvider(): EmailProvider {
  */
 export async function sendEmailUniversal(options: {
   to: string;
-  templateType: "verification" | "passwordReset" | "invite" | "mfa" | "paymentFailed" | "paymentRetry" | "subscriptionSuspended";
+  templateType:
+    | "verification"
+    | "passwordReset"
+    | "invite"
+    | "mfa"
+    | "paymentFailed"
+    | "paymentRetry"
+    | "subscriptionSuspended";
   dynamicTemplateData: Record<string, any>;
   fromName?: string;
+  userId?: string;
 }): Promise<void> {
   const provider = getEmailProvider();
 

--- a/apps/firebase/functions/src/auth/modules/authentication.ts
+++ b/apps/firebase/functions/src/auth/modules/authentication.ts
@@ -325,6 +325,7 @@ export const handleSignUp = onCall({
           username: signupData.email.split("@")[0], // Use email username as fallback since we don't have names yet
           verificationLink: verificationLink,
         },
+        userId,
       });
 
       logger.info("Successfully completed simplified signup process", createLogContext({

--- a/apps/firebase/functions/src/auth/modules/email-verification.ts
+++ b/apps/firebase/functions/src/auth/modules/email-verification.ts
@@ -80,6 +80,7 @@ export const sendVerificationEmail = onCall(
             userName: displayName || userData.firstName || "User",
             verificationUrl: verificationLink, // Note: changed from verificationLink to verificationUrl for template consistency
           },
+          userId: request.auth?.uid,
         });
 
         logger.info(`Verification email sent successfully to ${email} for user ${request.auth?.uid}`);

--- a/apps/firebase/functions/src/auth/modules/family-invitations.ts
+++ b/apps/firebase/functions/src/auth/modules/family-invitations.ts
@@ -104,6 +104,7 @@ export const sendFamilyTreeInvitation = onCall({
         acceptLink: invitationLink,
         year: new Date().getFullYear(),
       },
+      userId: invitationData.inviteeId,
     });
     logger.info(`Successfully sent invitation email to ${invitationData.inviteeEmail}`);
 

--- a/apps/firebase/functions/src/auth/modules/password-management.ts
+++ b/apps/firebase/functions/src/auth/modules/password-management.ts
@@ -99,6 +99,7 @@ export const initiatePasswordReset = onCall({
           username: displayName,
           resetLink: resetLink,
         },
+        userId: userRecord.uid,
       });
       logger.info("Password reset email sent successfully", createLogContext({email}));
 

--- a/apps/firebase/functions/src/familyTree.ts
+++ b/apps/firebase/functions/src/familyTree.ts
@@ -708,6 +708,7 @@ export const createFamilyMember = onCall(
               signUpLink: invitationLink,
               year: new Date().getFullYear(),
             },
+            userId: invitationData.inviteeId,
           });
           logger.info(
             `Sent invitation email to ${userData.email} for family tree ${userData.familyTreeId}`
@@ -1200,6 +1201,7 @@ export const updateFamilyMember = onCall(
               signUpLink: invitationLink,
               year: new Date().getFullYear(),
             },
+            userId: invitationData.inviteeId,
           });
           logger.info(`Sent invitation email to ${updates.email} for family tree ${familyTreeId}`);
         } catch (emailError) {

--- a/apps/firebase/functions/src/services/paymentRecoveryService.ts
+++ b/apps/firebase/functions/src/services/paymentRecoveryService.ts
@@ -567,6 +567,7 @@ export class PaymentRecoveryService {
           subject,
           urgency,
         },
+        userId: subscription.userId,
       });
 
       logger.info("Dunning email sent", {
@@ -603,6 +604,7 @@ export class PaymentRecoveryService {
           subject: "Payment Successful - Your Subscription is Active",
           emailType: "payment_success",
         },
+        userId: subscription.userId,
       });
     } catch (error) {
       logger.error("Failed to send payment success email", {
@@ -632,6 +634,7 @@ export class PaymentRecoveryService {
           reactivateUrl: `${process.env.FRONTEND_URL || "https://mydynastyapp.com"}/account/billing/reactivate`,
           subject: "Subscription Suspended - Payment Required",
         },
+        userId: subscription.userId,
       });
     } catch (error) {
       logger.error("Failed to send suspension email", {
@@ -661,6 +664,7 @@ export class PaymentRecoveryService {
           subject: "Subscription Reactivated - Welcome Back!",
           emailType: "subscription_reactivated",
         },
+        userId: subscription.userId,
       });
     } catch (error) {
       logger.error("Failed to send reactivation email", {


### PR DESCRIPTION
## Summary
- allow passing userId to `sendEmailUniversal`
- use userId when known in password reset, signup, verification and invitation flows
- include userId in SES helper calls for payment emails
- update tests for new email signature

## Testing
- `yarn lint:all` *(fails: package not present in lockfile)*
- `npm run test:all` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_684b87ecf144832ab24f05293a51404c