### PR TITLE
Set vercel install command to focus on web workspace

### DIFF
--- a/apps/web/dynastyweb/vercel.json
+++ b/apps/web/dynastyweb/vercel.json
@@ -1,7 +1,7 @@
 {
   "buildCommand": "yarn build",
   "outputDirectory": ".next",
-  "installCommand": "yarn install --frozen-lockfile",
+  "installCommand": "yarn workspaces focus dynastyweb --production",
   "framework": "nextjs",
   "build": {
     "env": {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-    "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && yarn install",
+    "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && yarn workspaces focus dynastyweb --production",
     "buildCommand": "yarn build",
     "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- update vercel install command to only install web workspace deps

## Testing
- `yarn lint:all` *(fails: command exited with error)*
- `yarn test:all` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_684f40829ae8832aa71406e4fa4ec170