### PR TITLE
Fix missing vault-sdk build on install

### DIFF
--- a/packages/vault-sdk/package.json
+++ b/packages/vault-sdk/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepare": "yarn build",
     "build:watch": "tsc -p tsconfig.build.json --watch",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary
- ensure vault-sdk is built when installed by adding a `prepare` script

## Testing
- `yarn lint:all` *(fails: command `/tmp/xfs-a54b3d66/yarn run lint` exited with 1)*
- `yarn test:all` *(fails: command `/tmp/xfs-eb35f1db/yarn run test` exited with 1)*

------
https://chatgpt.com/codex/tasks/task_b_684f9d233f70832a8421b65d6f263a62