### PR TITLE
Fix subscription storage calculation

### DIFF
--- a/apps/web/dynastyweb/src/app/(protected)/account-settings/subscription/page.tsx
+++ b/apps/web/dynastyweb/src/app/(protected)/account-settings/subscription/page.tsx
@@ -366,7 +366,7 @@ export default function SubscriptionPage() {
           />
           <div className="flex justify-between text-sm text-gray-600">
             <span>{storagePercentage.toFixed(0)}% used</span>
-            <span>{((totalStorageGB * 1024 * 1024 * 1024 - storageData?.usedBytes || 0) / (1024 * 1024 * 1024)).toFixed(1)} GB available</span>
+            <span>{((totalStorageGB * 1024 * 1024 * 1024 - (storageData?.usedBytes ?? 0)) / (1024 * 1024 * 1024)).toFixed(1)} GB available</span>
           </div>
           
           {/* Storage breakdown if available */}
@@ -411,7 +411,7 @@ export default function SubscriptionPage() {
               <AlertCircle className="h-4 w-4 text-orange-600" />
               <AlertTitle className="text-orange-800">Storage Almost Full</AlertTitle>
               <AlertDescription className="text-orange-700">
-                You&apos;re using {storagePercentage.toFixed(0)}% of your storage. Only {((totalStorageGB * 1024 * 1024 * 1024 - storageData?.usedBytes || 0) / (1024 * 1024 * 1024)).toFixed(1)} GB remaining. 
+                You&apos;re using {storagePercentage.toFixed(0)}% of your storage. Only {((totalStorageGB * 1024 * 1024 * 1024 - (storageData?.usedBytes ?? 0)) / (1024 * 1024 * 1024)).toFixed(1)} GB remaining.
                 <Button 
                   variant="link" 
                   className="h-auto p-0 text-orange-700 underline ml-1"


### PR DESCRIPTION
## Summary
- handle undefined storage bytes in subscription page

## Testing
- `yarn lint:all` *(fails: Definition for rule '@typescript-eslint/no-explicit-any' was not found)*
- `yarn test:all` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_684fb393cbc4832aaf8d0e01a11ceace