### PR TITLE
Update Stripe dependency to support 2025 API

### DIFF
--- a/apps/web/dynastyweb/package.json
+++ b/apps/web/dynastyweb/package.json
@@ -95,7 +95,7 @@
     "react-window": "^1.8.8",
     "recharts": "^2.15.3",
     "relatives-tree": "^3.2.1",
-    "stripe": "^14.0.0",
+    "stripe": "^18.2.1",
     "swiper": "^11.2.8",
     "tailwind-merge": "^3.0.1",
     "tailwindcss": "^3.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9379,7 +9379,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:>=8.1.0, @types/node@npm:^24":
+"@types/node@npm:*, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^24":
   version: 24.0.1
   resolution: "@types/node@npm:24.0.1"
   dependencies:
@@ -12965,7 +12965,7 @@ __metadata:
     react-window: "npm:^1.8.8"
     recharts: "npm:^2.15.3"
     relatives-tree: "npm:^3.2.1"
-    stripe: "npm:^14.0.0"
+    stripe: "npm:^18.2.1"
     swiper: "npm:^11.2.8"
     tailwind-merge: "npm:^3.0.1"
     tailwindcss: "npm:^3.4.1"
@@ -23710,16 +23710,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10c0/7edef67ca27bd4e84ac24eae4e10fa1d712392c08eec62aa6748c78241ebccc2a057651716a619fcaac1b70c5f08ba5fc5adf255d67462d5a441e3a96c0dc6c5
-  languageName: node
-  linkType: hard
-
-"stripe@npm:^14.0.0":
-  version: 14.25.0
-  resolution: "stripe@npm:14.25.0"
-  dependencies:
-    "@types/node": "npm:>=8.1.0"
-    qs: "npm:^6.11.0"
-  checksum: 10c0/3f98230d537bdcb9e31775576743e9f2e2137d45021b3a59afe5af17dc54397e8f27bab7abce6fbb81545f69dc73f4c1325c987d2e0c88c2149e135c783d14ff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- update Stripe in `dynastyweb` workspace so Typescript recognizes new API version

## Testing
- `yarn lint:all` *(fails: command exited with error)*
- `yarn test:all` *(fails: command exited with error)*

------
https://chatgpt.com/codex/tasks/task_b_68503a8bf1b0832abc11b6c878f774b8