### PR TITLE
Fix PostCSS config for Vercel

### DIFF
--- a/apps/web/dynastyweb/postcss.config.mjs
+++ b/apps/web/dynastyweb/postcss.config.mjs
@@ -1,8 +1,6 @@
 /** @type {import('postcss-load-config').Config} */
-import tailwindcss from '@tailwindcss/postcss';
-
-const config = {
-  plugins: [tailwindcss],
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- fix PostCSS config to use plugin name instead of function

## Testing
- `yarn lint:all` *(fails: command exited with code 1)*
- `yarn test:all` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68518e33bce8832aba596a518d0a1ec7