### PR TITLE
Fix missing vault service import

### DIFF
--- a/apps/web/dynastyweb/src/components/vault/VaultMonitoringDashboard.tsx
+++ b/apps/web/dynastyweb/src/components/vault/VaultMonitoringDashboard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { vaultSDKService } from '@/services/VaultSDKService';
+import { vaultService } from '@/services/VaultService';
 import { useFeatureFlags } from '@/lib/feature-flags';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';


### PR DESCRIPTION
## Summary
- import the legacy `vaultService` in the VaultMonitoringDashboard component

## Testing
- `yarn lint:all` *(fails: command exited with code 1)*
- `yarn test:all` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68519f64bd48832a97c995f9495255f7