### PR TITLE
fix missing vault service for system stats

### DIFF
--- a/apps/web/dynastyweb/src/components/vault/VaultMonitoringDashboard.tsx
+++ b/apps/web/dynastyweb/src/components/vault/VaultMonitoringDashboard.tsx
@@ -168,7 +168,7 @@ export default function VaultMonitoringDashboard({ isAdmin = false }: { isAdmin?
         if (isAdmin) {
           try {
             // System stats always use legacy service for now
-            const sysStats = await vaultSDKService.getSystemVaultStats();
+            const sysStats = await vaultService.getSystemVaultStats();
             setSystemStats(sysStats);
             if (useSDK) {
               limitations.push('System statistics using legacy service');


### PR DESCRIPTION
## Summary
- ensure legacy VaultService is used to load system stats in dashboard

## Testing
- `yarn lint:all` *(fails: Unexpected any in many files)*
- `yarn test:all` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_6851a38a9474832a80f870d39a09ea4f