### PR TITLE
Fix libsodium tar warnings in CI

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
-    "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn install",
+    "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && YARN_ENABLE_IMMUTABLE_INSTALLS=false TAR_OPTIONS=\"--warning=no-unknown-keyword\" yarn install",
     "buildCommand": "yarn workspace @dynasty/vault-sdk build && yarn workspace dynastyweb build",
     "outputDirectory": "apps/web/dynastyweb/.next",
     "framework": "nextjs"


### PR DESCRIPTION
## Summary
- suppress tar warning spam for react-native-libsodium during `yarn install`

## Testing
- `yarn lint:all` *(fails: command exited with code 1)*
- `yarn test:all` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_6851a3a5ac08832a801dfb978db211ba