### PR TITLE
Fix vault monitoring types

### DIFF
--- a/apps/web/dynastyweb/src/services/VaultSDKPerformanceMonitor.ts
+++ b/apps/web/dynastyweb/src/services/VaultSDKPerformanceMonitor.ts
@@ -11,7 +11,18 @@ import { cacheService } from './CacheService';
 // Performance metric interfaces
 export interface VaultOperationMetric {
   operationId: string;
-  operation: 'upload' | 'download' | 'delete' | 'share' | 'encrypt' | 'decrypt' | 'list';
+  operation:
+    | 'upload'
+    | 'download'
+    | 'delete'
+    | 'share'
+    | 'encrypt'
+    | 'decrypt'
+    | 'list'
+    | 'create'
+    | 'search'
+    | 'move'
+    | 'restore';
   startTime: number;
   endTime: number;
   duration: number;


### PR DESCRIPTION
## Summary
- extend `VaultOperationMetric` to include create, search, move and restore operations

## Testing
- `yarn lint:all` *(fails: @dynasty/vault-sdk lint issues)*
- `yarn test:all` *(fails: cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_6851a8849a80832a92b6da651aef55df