### PR TITLE
Remove obsolete react-hooks package rule

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -21,8 +21,3 @@ packageExtensions:
   "@callstack/react-theme-provider@*":
     peerDependencies:
       react: "*"
-  "@testing-library/react-hooks@*":
-    peerDependencies:
-      "@types/react": "*"
-      react: "*"
-      react-dom: "*"


### PR DESCRIPTION
## Summary
- remove `@testing-library/react-hooks` from yarnrc packageExtensions

## Testing
- `yarn lint:all` *(fails: dynastyweb#lint)*
- `yarn test:all` *(fails: @dynasty/vault-sdk#test)*

------
https://chatgpt.com/codex/tasks/task_b_6851aa605588832aa6b42d155cdc5d0a