### PR TITLE
Fix folder type in VaultSDKService

### DIFF
--- a/apps/web/dynastyweb/src/services/VaultSDKService.ts
+++ b/apps/web/dynastyweb/src/services/VaultSDKService.ts
@@ -527,15 +527,12 @@ class VaultSDKService {
       const folder: VaultFolder = {
         id: result.id,
         name: result.name,
-        type: 'folder' as const,
         parentId: result.parentId,
         path: result.path,
         createdAt: new Date(result.createdAt),
         updatedAt: new Date(result.updatedAt),
-        isShared: (result.sharedWith?.length || 0) > 0,
-        sharedWith: result.sharedWith,
         itemCount: 0, // SDK doesn't provide this yet
-        size: 0, // SDK doesn't provide this yet
+        totalSize: 0, // SDK doesn't provide this yet
       };
       
       return folder;


### PR DESCRIPTION
## Summary
- remove invalid fields in VaultSDKService createFolder return object

## Testing
- `yarn lint:all` *(fails: various lint errors in dynastyweb)*
- `yarn test:all` *(fails: jest SyntaxError in packages/vault-sdk)*

------
https://chatgpt.com/codex/tasks/task_b_6851aad05814832a80aa498cf788b274