### PR TITLE
Fix VaultSDKService search & deleted items

### DIFF
--- a/apps/web/dynastyweb/src/services/VaultSDKService.ts
+++ b/apps/web/dynastyweb/src/services/VaultSDKService.ts
@@ -643,15 +643,15 @@ class VaultSDKService {
       const result = await this.apiClient.searchItems({
         query,
         fileTypes: filters?.type === 'file' ? [
-          filters.mimeType?.includes('image') ? 'image' : 
+          filters.mimeType?.includes('image') ? 'image' :
           filters.mimeType?.includes('video') ? 'video' :
           filters.mimeType?.includes('audio') ? 'audio' :
           filters.mimeType?.includes('document') ? 'document' : 'other'
         ].filter(Boolean) as any : undefined,
       });
-      
+
       // Convert SDK items to legacy format
-      let items = result.items.map(item => this.convertSDKItemToLegacy(item));
+      let items = result.map(item => this.convertSDKItemToLegacy(item));
       
       // Apply client-side filtering
       if (filters) {
@@ -945,9 +945,9 @@ class VaultSDKService {
     
     try {
       const result = await this.apiClient.getDeletedItems();
-      
+
       // Convert SDK items to legacy format
-      const items = result.items.map(item => this.convertSDKItemToLegacy(item));
+      const items = result.map(item => this.convertSDKItemToLegacy(item));
       
       // End performance monitoring - success
       vaultSDKPerformanceMonitor.endOperation(deletedId, true, undefined, {


### PR DESCRIPTION
## Summary
- handle array responses from `searchItems` and `getDeletedItems`

## Testing
- `yarn lint:all` *(fails: no-unused-vars, no-explicit-any)*
- `yarn test:all` *(fails: SyntaxError: Cannot use import statement outside a module)*


------
https://chatgpt.com/codex/tasks/task_b_6851b402388c832a8e3d93c892577093