### PR TITLE
fix tailwind darkmode configuration

### DIFF
--- a/apps/web/dynastyweb/tailwind.config.ts
+++ b/apps/web/dynastyweb/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 
 export default {
-    darkMode: ["class"],
+    darkMode: 'class',
     content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- correct Tailwind `darkMode` configuration in dynastyweb

## Testing
- `yarn lint:all` *(fails: dynastyweb#lint)*
- `yarn test:all` *(fails: @dynasty/vault-sdk#test)*

------
https://chatgpt.com/codex/tasks/task_b_6851ba5f61c8832aaee30648906c4e14