### PR TITLE
fix: correct output directory for Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
     "installCommand": "corepack enable && corepack prepare yarn@4.9.2 --activate && YARN_ENABLE_IMMUTABLE_INSTALLS=false TAR_OPTIONS=\"--warning=no-unknown-keyword\" yarn install",
     "buildCommand": "yarn workspace @dynasty/vault-sdk build && yarn workspace dynastyweb build",
-    "outputDirectory": "apps/web/dynastyweb/.next",
+    "outputDirectory": ".next",
     "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- fix outputDirectory so Vercel looks in the right `.next` folder

## Testing
- `yarn lint:all` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `yarn test:all` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_6851db6bfd18832aaa8431891fa0a3f1