### PR TITLE
Fix web styling by restoring postcss plugins

### DIFF
--- a/apps/web/dynastyweb/postcss.config.mjs
+++ b/apps/web/dynastyweb/postcss.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
+    autoprefixer: {},
   },
 };

--- a/apps/web/dynastyweb/src/app/globals.css
+++ b/apps/web/dynastyweb/src/app/globals.css
@@ -38,6 +38,14 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 145 78% 20%; /* Deep Forest Green for sidebar ring */
+
+    /* Legacy variable aliases */
+    --text-color: hsl(var(--foreground));
+    --background-color: hsl(var(--background));
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary, var(--primary)));
+    --border-radius: var(--radius);
+    --transition-speed: 0.2s;
   }
 
   .dark {
@@ -75,6 +83,14 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 145 60% 25%; /* Adjusted sidebar ring for dark mode */
+
+    /* Legacy variable aliases */
+    --text-color: hsl(var(--foreground));
+    --background-color: hsl(var(--background));
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary, var(--primary)));
+    --border-radius: var(--radius);
+    --transition-speed: 0.2s;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore expected Tailwind processing by updating `postcss.config.mjs`
- add legacy CSS variable aliases for compatibility

## Testing
- `yarn lint:all` *(fails: @typescript-eslint errors)*
- `yarn test:all` *(fails: Jest syntax error in vault-sdk)*

------
https://chatgpt.com/codex/tasks/task_b_68523c1aef10832a8a244e25ac9541e8