### PR TITLE
Fix styling variables for dynastyweb

### DIFF
--- a/apps/web/dynastyweb/src/app/globals.css
+++ b/apps/web/dynastyweb/src/app/globals.css
@@ -38,6 +38,14 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 220 13% 91%;
     --sidebar-ring: 145 78% 20%; /* Deep Forest Green for sidebar ring */
+
+    /* Legacy CSS variable aliases */
+    --text-color: hsl(var(--foreground));
+    --background-color: hsl(var(--background));
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary, var(--primary)));
+    --border-radius: var(--radius);
+    --transition-speed: 200ms;
   }
 
   .dark {
@@ -75,6 +83,14 @@
     --sidebar-accent-foreground: 240 4.8% 95.9%;
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 145 60% 25%; /* Adjusted sidebar ring for dark mode */
+
+    /* Legacy CSS variable aliases */
+    --text-color: hsl(var(--foreground));
+    --background-color: hsl(var(--background));
+    --primary-color: hsl(var(--primary));
+    --secondary-color: hsl(var(--secondary, var(--primary)));
+    --border-radius: var(--radius);
+    --transition-speed: 200ms;
   }
 }
 


### PR DESCRIPTION
## Summary
- restore legacy CSS variable aliases so theme colors apply correctly

## Testing
- `yarn lint:all` *(fails: dynastyweb lint errors)*
- `yarn test:all` *(fails: vault-sdk test setup issue)*

------
https://chatgpt.com/codex/tasks/task_b_68523c1aef10832a8a244e25ac9541e8